### PR TITLE
[Fix] Escape vertical bar

### DIFF
--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -18,6 +18,7 @@ syntax keyword nickelKeywords
     \ doc
     \ default
     \ fun
+    \ forall
 
 " Operators
 syntax keyword nickelOperator
@@ -27,12 +28,17 @@ syntax keyword nickelOperator
     \ <=
     \ >
     \ >=
-    \ =>
+    \ &&
+    \ \|\|
+    \ +
+    \ -
+    \ *
+    \ /
     \ ++
     \ @
     \ ->
     \ :
-    \ |
+    \ \|
     \ =
     \ %
 


### PR DESCRIPTION
I added the vertical bar `|` in operators in last and haven't tested it in #3. My bad, those need to be escaped in vim-script, which was causing syntax error in `nickel.vim`. This PR fixes it and add a few missing operators too.