### PR TITLE
Update settings for comments

### DIFF
--- a/ftplugin/nickel.vim
+++ b/ftplugin/nickel.vim
@@ -1,5 +1,4 @@
-setlocal commentstring=//%s
-setlocal iskeyword+=#
+setlocal commentstring=#%s
 setlocal tabstop=2
 setlocal shiftwidth=2
 setlocal expandtab


### PR DESCRIPTION
- Update `commentstring` to use `#` comments instead of the old `//` comments
- Remove `#` from `iskeyword`, it was removed from custom contract application