### PR TITLE
Update/0.3

### DIFF
--- a/indent/nickel.vim
+++ b/indent/nickel.vim
@@ -1,20 +1,20 @@
 setlocal indentexpr=NickelIndent()
 
 function! NickelIndent()
-	let line = getline(v:lnum)
-	let previousNum = prevnonblank(v:lnum - 1)
-	let previous = getline(previousNum)
-	let currentIndent = indent(previousNum)
+    let line = getline(v:lnum)
+    let previousNum = prevnonblank(v:lnum - 1)
+    let previous = getline(previousNum)
+    let currentIndent = indent(previousNum)
 
-	if previous =~ "{$" && previous !~ "}" && line !~ "}"
-		return currentIndent + &tabstop
-	endif
+    if previous =~ "{$" && previous !~ "}" && line !~ "}"
+        return currentIndent + &tabstop
+    endif
 
-	if previous =~ "if$" || previous =~ "then$" || previous =~ "else$"
-		return currentIndent + &tabstop
-	endif
+    if previous =~ "if$" || previous =~ "then$" || previous =~ "else$"
+        return currentIndent + &tabstop
+    endif
 
-	if previous =~ "fun" && previous =~ "=>$"
-		return currentIndent + &tabstop
-	endif
+    if previous =~ "fun" && previous =~ "=>$"
+        return currentIndent + &tabstop
+    endif
 endfunction

--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -8,17 +8,27 @@ syntax region nickelComment start="#" end="$" contains=@Spell oneline display
 
 " Commands
 syntax keyword nickelKeywords
-    \ switch
-    \ import
-    \ if
-    \ else
-    \ then
     \ let
     \ in
+    \ fun
+    \ rec
+
+syntax keyword nickelImport import
+
+" Control flow
+syntax keyword nickelControlFlow
+    \ if
+    \ then
+    \ else
+    \ match
+
+syntax keyword nickelMetadata
     \ doc
     \ default
-    \ fun
-    \ forall
+    \ force
+    \ optional
+    \ priority
+
 
 " Operators
 syntax keyword nickelOperator
@@ -42,31 +52,49 @@ syntax keyword nickelOperator
     \ =
     \ %
 
-" Types and Contracts (convention)
-syntax match nickelTypeContract "\v<[A-Z_\$][a-zA-Z0-9_\$]*>"
 
 " Identifier
-syntax match nickelIdentifier "\v<[a-z_\$][a-zA-Z0-9-_\$]*>"
-syntax match nickelBuiltin "\v\%[a-zA-Z0-9_\$]*\%"
+syntax match nickelIdentifier "\v<[a-z_][a-zA-Z0-9-_']*>"
+syntax match nickelBuiltin "\v\%[a-zA-Z0-9_]*\%"
+
+syntax keyword nickelTypeContract forall
+
+" Types and Contracts (convention)
+" Include contracts extracted from a record, like num.Nat. This matches a
+" sequence of record field access which ends with an identifier starting with an
+" upper-case letter.
+syntax match nickelTypeContract "\v<([a-z_][a-zA-Z0-9-_']*\.)*[A-Z][a-zA-Z0-9_]*>"
+
+" Single enum tag
+syntax match nickelEnumTag "\v`[a-zA-Z_][a-zA-Z0-9-_']*>"
+syntax region nickelEnumTag start=+`"+ skip=+\\"+ end=+"+ oneline
+
+" Enum type
+syntax region nickelTypeContract start=+\[|+ end=+|]+ contains=nickelEnumTag
 
 " Strings
 syntax region nickelString start=+"+ skip=+\\"+ end=+"+ oneline
-syntax region nickelString start=+m%"+ end=+"%m+
-syntax region nickelString start=+m%%"+ end=+"%%m+
-syntax region nickelString start=+m%%%"+ end=+"%%%m+
+syntax region nickelString start=+m%"+ end=+"%+
+syntax region nickelString start=+m%%"+ end=+"%%+
+syntax region nickelString start=+m%%%"+ end=+"%%%+
+syntax region nickelString start=+m%%%%"+ end=+"%%%%+
 
 " Number
-syntax match nickelInt "[0-9]\+"
-syntax match nickelHex "0[xX][0-9a-fA-F]\+\\b"
-syntax match nickelFloat "[+-]?\\d\+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d\+)?)?\\b"
+syntax match nickelFloat "\v[+-]?\d+((\.\d+)?([eE][+-]?\d+)?)?"
+" Float starting by a dot
+syntax match nickelFloat "\v[+-]?\.\d+([eE][+-]?\d+)?"
+syntax match nickelHex "\v0[xX][0-9a-fA-F]+"
 
-highlight def link nickelComment      Comment
-highlight def link nickelKeywords     Function
-highlight def link nickelOperator     Operator
-highlight def link nickelTypeContract Type
-highlight def link nickelIdentifier   Normal
-highlight def link nickelBuiltin      Special
-highlight def link nickelString       String
-highlight def link nickelFloat        Float
-highlight def link nickelHex          Number
-highlight def link nickelInt          Number
+hi def link nickelComment      Comment
+hi def link nickelKeywords     Keyword
+hi def link nickelMetadata     Special
+hi def link nickelImport       Include
+hi def link nickelControlFlow  Statement
+hi def link nickelOperator     Operator
+hi def link nickelTypeContract Type
+hi def link nickelEnumTag      Constant
+hi def link nickelIdentifier   Normal
+hi def link nickelBuiltin      Function
+hi def link nickelString       String
+hi def link nickelFloat        Float
+hi def link nickelHex          Number


### PR DESCRIPTION
This commit updates the syntax to match the one of the current stable
version of Nickel (0.3).

Doing so, we also made the highlighting groups slighty more natural: we
distinguish between statements-like keyword and metadata keyword (which
are highlighted in a different way), highlight builtins like functions,
and fixed a few regular expressions.