### PR TITLE
Update to upstream enum tag syntax

### DIFF
--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -66,8 +66,8 @@ syntax keyword nickelTypeContract forall
 syntax match nickelTypeContract "\v<([a-z_][a-zA-Z0-9-_']*\.)*[A-Z][a-zA-Z0-9_]*>"
 
 " Single enum tag
-syntax match nickelEnumTag "\v`[a-zA-Z_][a-zA-Z0-9-_']*>"
-syntax region nickelEnumTag start=+`"+ skip=+\\"+ end=+"+ oneline
+syntax match nickelEnumTag "\v'[a-zA-Z_][a-zA-Z0-9-_']*>"
+syntax region nickelEnumTag start=+'"+ skip=+\\"+ end=+"+ oneline
 
 " Enum type
 syntax region nickelTypeContract start=+\[|+ end=+|]+ contains=nickelEnumTag


### PR DESCRIPTION
Upstream Nickel changed the enum tag character from backtick ` to single quote '. Update the Nickel grammar definition to reflect this change.

This PR is merged into main directly, but I've create the `stable` and `0.3.2` branches in the meantime. I think it's more manageable to do that on all Nickel repos: instead of having to maintain the state of stable into `main`, we should rather point to the `stable` branch in various guides, and have `main` follow Nickel's `master`.