### PR TITLE
Make it possible to disable default style

### DIFF
--- a/ftplugin/nickel.vim
+++ b/ftplugin/nickel.vim
@@ -1,5 +1,7 @@
 setlocal commentstring=#%s
-setlocal tabstop=2
-setlocal shiftwidth=2
-setlocal expandtab
+
+if get(g:, 'nickel_recommended_style', 1)
+    setlocal tabstop=2 shiftwidth=2 expandtab
+endif
+
 setlocal completefunc=syntaxcomplete#Complete


### PR DESCRIPTION
Closes #8.

The default style set by the Nickel plugin affects options such as tabwidth, tabstop, etc. This can conflict with user-defined specific settings (including accessibility-related ones), or `.editorconfig`.

After this PR, the plugin sets this style only if some flag isn't set. The style is still set by default, but can be disabled if needed.