### PR TITLE
Improve strings and string interpolation syntax

### DIFF
--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -73,10 +73,10 @@ syntax region nickelEnumTag start=+'"+ skip=+\\"+ end=+"+ oneline
 " Enum type
 syntax region nickelTypeContract start=+\[|+ end=+|]+ contains=nickelEnumTag
 
-syntax match nickelInterpolation1 "\v\%\{([^\}])*\}"
-syntax match nickelInterpolation2 "\v\%\%\{([^\}])*\}"
-syntax match nickelInterpolation3 "\v\%\%\%\{([^\}])*\}"
-syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}])*\}"
+syntax match nickelInterpolation1 "\v\%\{([^\}]|\n)*\}"
+syntax match nickelInterpolation2 "\v\%\%\{([^\}]|\n)*\}"
+syntax match nickelInterpolation3 "\v\%\%\%\{([^\}]|\n)*\}"
+syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}]|\n)*\}"
 
 " Strings
 syntax region nickelString start=+"+ skip=+\\"+ end=+"+ contains=nickelInterpolation1 oneline

--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -80,10 +80,10 @@ syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}]|\n)*\}" contains=nickelCom
 
 " Strings
 syntax region nickelString start=+"+ skip=+\\"+ end=+"+ contains=nickelInterpolation1 oneline
-syntax region nickelString start=!\([a-z]\+-s\|m\)%"! end=+"%+ contains=nickelInterpolation1
-syntax region nickelString start=!\([a-z]\+-s\|m\)%%"! end=+"%%+ contains=nickelInterpolation2
-syntax region nickelString start=!\([a-z]\+-s\|m\)%%%"! end=+"%%%+ contains=nickelInterpolation3
-syntax region nickelString start=!\([a-z]\+-s\|m\)%%%%"! end=+"%%%%+ contains=nickelInterpolation4
+syntax region nickelString start=!\([a-z]\+-s\|m\)%"! skip=+"%{+ end=+"%+ contains=nickelInterpolation1
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%"! skip=+"%%{+ end=+"%%+ contains=nickelInterpolation2
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%%"! skip=+"%%%{+ end=+"%%%+ contains=nickelInterpolation3
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%%%"! skip=+"%%%%{+ end=+"%%%%+ contains=nickelInterpolation4
 
 " Number
 syntax match nickelFloat "\v[+-]?\d+((\.\d+)?([eE][+-]?\d+)?)?"

--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -73,10 +73,10 @@ syntax region nickelEnumTag start=+'"+ skip=+\\"+ end=+"+ oneline
 " Enum type
 syntax region nickelTypeContract start=+\[|+ end=+|]+ contains=nickelEnumTag
 
-syntax match nickelInterpolation1 "\v\%\{([^\}]|\n)*\}"
-syntax match nickelInterpolation2 "\v\%\%\{([^\}]|\n)*\}"
-syntax match nickelInterpolation3 "\v\%\%\%\{([^\}]|\n)*\}"
-syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}]|\n)*\}"
+syntax match nickelInterpolation1 "\v\%\{([^\}]|\n)*\}" contains=nickelComment,nickelKeywords,nickelImport,nickelControlFlow,nickelMetadata,nickelOperator,nickelParens,nickelIdentifier,nickelBuiltin,nickelTypeContract,nickelEnumTag,nickelString,nickelFloat,nickelHex
+syntax match nickelInterpolation2 "\v\%\%\{([^\}]|\n)*\}" contains=nickelComment,nickelKeywords,nickelImport,nickelControlFlow,nickelMetadata,nickelOperator,nickelParens,nickelIdentifier,nickelBuiltin,nickelTypeContract,nickelEnumTag,nickelString,nickelFloat,nickelHex
+syntax match nickelInterpolation3 "\v\%\%\%\{([^\}]|\n)*\}" contains=nickelComment,nickelKeywords,nickelImport,nickelControlFlow,nickelMetadata,nickelOperator,nickelParens,nickelIdentifier,nickelBuiltin,nickelTypeContract,nickelEnumTag,nickelString,nickelFloat,nickelHex
+syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}]|\n)*\}" contains=nickelComment,nickelKeywords,nickelImport,nickelControlFlow,nickelMetadata,nickelOperator,nickelParens,nickelIdentifier,nickelBuiltin,nickelTypeContract,nickelEnumTag,nickelString,nickelFloat,nickelHex
 
 " Strings
 syntax region nickelString start=+"+ skip=+\\"+ end=+"+ contains=nickelInterpolation1 oneline

--- a/syntax/nickel.vim
+++ b/syntax/nickel.vim
@@ -80,10 +80,10 @@ syntax match nickelInterpolation4 "\v\%\%\%\%\{([^\}])*\}"
 
 " Strings
 syntax region nickelString start=+"+ skip=+\\"+ end=+"+ contains=nickelInterpolation1 oneline
-syntax region nickelString start=+m%"+ end=+"%+ contains=nickelInterpolation1
-syntax region nickelString start=+m%%"+ end=+"%%+ contains=nickelInterpolation2
-syntax region nickelString start=+m%%%"+ end=+"%%%+ contains=nickelInterpolation3
-syntax region nickelString start=+m%%%%"+ end=+"%%%%+ contains=nickelInterpolation4
+syntax region nickelString start=!\([a-z]\+-s\|m\)%"! end=+"%+ contains=nickelInterpolation1
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%"! end=+"%%+ contains=nickelInterpolation2
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%%"! end=+"%%%+ contains=nickelInterpolation3
+syntax region nickelString start=!\([a-z]\+-s\|m\)%%%%"! end=+"%%%%+ contains=nickelInterpolation4
 
 " Number
 syntax match nickelFloat "\v[+-]?\d+((\.\d+)?([eE][+-]?\d+)?)?"


### PR DESCRIPTION
Fix things that were wrong with highlighting string in https://github.com/nickel-lang/nickel-nix/blob/f1f0d74d8554e39fc4a350da41d25cdc19b418ed/lib/builders.ncl#L113-L127:

- Add symbolic strings to nickelString
- Catch multiline string interpolations
- Highlight everything inside string interpolation
- Skip interpolation points when looking for string end
